### PR TITLE
Duplicate products pr

### DIFF
--- a/lowest-price.php
+++ b/lowest-price.php
@@ -118,6 +118,9 @@ class Lowest_Price {
 
     public function init_actions() {
 
+        add_filter( 'woocommerce_duplicate_product_exclude_meta', array( $this, 'exclude_meta' ) );
+        add_action( 'woocommerce_product_duplicate_before_save', array( $this, 'delete_child_meta' ), 999, 2 );
+        
         add_action( 'woocommerce_update_product', array( $this, 'product_update' ) );
         add_action( 'woocommerce_update_product_variation', array( $this, 'variation_update' ) );
 
@@ -195,11 +198,20 @@ class Lowest_Price {
 
     }
 
+    public function exclude_meta() {
+        return array( '_lowest_price_30_days', '_regular_price', '_sale_price', '_min_variation_price', '_max_variation_price', '_min_variation_regular_price', '_max_variation_regular_price', '_min_variation_sale_price', '_max_variation_sale_price' );
+    }
+
+    public function delete_child_meta( $child_duplicate, $child ) {
+        foreach ( $this->exclude_meta() as $meta_key ) {
+            $child_duplicate->delete_meta_data( $meta_key );
+        }
+    }
+
     public function update_price( $object_id, $new_price, $regular_price ) {
 
         if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
-            delete_post_meta( $object_id, '_lowest_price_30_days' );
-            return;
+            return true;
         }
 
         global $wpdb;
@@ -282,8 +294,7 @@ class Lowest_Price {
     public function object_before_update( $object ) {
 
         if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
-            delete_post_meta( $object->get_id(), '_lowest_price_30_days' );
-            return;
+            return true;
         }
 
         global $wpdb;

--- a/lowest-price.php
+++ b/lowest-price.php
@@ -197,6 +197,10 @@ class Lowest_Price {
 
     public function update_price( $object_id, $new_price, $regular_price ) {
 
+        if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
+            return;
+        }
+
         global $wpdb;
 
         $last_price = array(
@@ -275,6 +279,10 @@ class Lowest_Price {
     }
 
     public function object_before_update( $object ) {
+
+        if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
+            return;
+        }
 
         global $wpdb;
 

--- a/lowest-price.php
+++ b/lowest-price.php
@@ -200,10 +200,12 @@ class Lowest_Price {
     }
 
     public function update_price( $object_id, $new_price, $regular_price ) {
-
+        // On product copy, delete lowest price meta, and don't create DB entry.
+        $object = wc_get_product( $object_id );
         if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
             foreach ( $this->exclude_meta() as $meta_key ) {
-                delete_post_meta( $object_id, $meta_key );
+                $object->delete_meta_data( $meta_key );
+                // delete_post_meta( $object_id, $meta_key );
             }
             return true;
         }
@@ -286,13 +288,18 @@ class Lowest_Price {
     }
 
     public function object_before_update( $object ) {
-
+        // When product duplicated.
         if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
-            $object->set_price( null );
-            $object->set_regular_price( null );
-            $object->set_sale_price( null );
+            // Only for variations - don't duplicate prices.
+            if ( 'variation' === $object->get_type() ) {
+                $object->set_price( null );
+                $object->set_regular_price( null );
+                $object->set_sale_price( null );
+            }
+            // Delete meta for variable prices and meta fof lowest price.
             foreach ( $this->exclude_meta() as $meta_key ) {
-                delete_post_meta( $object->get_id(), $meta_key );
+                $object->delete_meta_data( $meta_key );
+                // delete_post_meta( $object->get_id(), $meta_key );
             }
             return true;
         }

--- a/lowest-price.php
+++ b/lowest-price.php
@@ -117,9 +117,6 @@ class Lowest_Price {
     }
 
     public function init_actions() {
-
-        add_filter( 'woocommerce_duplicate_product_exclude_meta', array( $this, 'exclude_meta' ) );
-        add_action( 'woocommerce_product_duplicate_before_save', array( $this, 'delete_child_meta' ), 999, 2 );
         
         add_action( 'woocommerce_update_product', array( $this, 'product_update' ) );
         add_action( 'woocommerce_update_product_variation', array( $this, 'variation_update' ) );
@@ -199,18 +196,15 @@ class Lowest_Price {
     }
 
     public function exclude_meta() {
-        return array( '_lowest_price_30_days', '_regular_price', '_sale_price', '_min_variation_price', '_max_variation_price', '_min_variation_regular_price', '_max_variation_regular_price', '_min_variation_sale_price', '_max_variation_sale_price' );
-    }
-
-    public function delete_child_meta( $child_duplicate, $child ) {
-        foreach ( $this->exclude_meta() as $meta_key ) {
-            $child_duplicate->delete_meta_data( $meta_key );
-        }
+        return array( '_lowest_price_30_days', '_min_variation_price', '_max_variation_price', '_min_variation_regular_price', '_max_variation_regular_price', '_min_variation_sale_price', '_max_variation_sale_price' );
     }
 
     public function update_price( $object_id, $new_price, $regular_price ) {
 
         if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
+            foreach ( $this->exclude_meta() as $meta_key ) {
+                delete_post_meta( $object_id, $meta_key );
+            }
             return true;
         }
 
@@ -294,6 +288,12 @@ class Lowest_Price {
     public function object_before_update( $object ) {
 
         if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
+            $object->set_price( null );
+            $object->set_regular_price( null );
+            $object->set_sale_price( null );
+            foreach ( $this->exclude_meta() as $meta_key ) {
+                delete_post_meta( $object->get_id(), $meta_key );
+            }
             return true;
         }
 

--- a/lowest-price.php
+++ b/lowest-price.php
@@ -205,7 +205,6 @@ class Lowest_Price {
         if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
             foreach ( $this->exclude_meta() as $meta_key ) {
                 $object->delete_meta_data( $meta_key );
-                // delete_post_meta( $object_id, $meta_key );
             }
             return true;
         }
@@ -299,7 +298,6 @@ class Lowest_Price {
             // Delete meta for variable prices and meta fof lowest price.
             foreach ( $this->exclude_meta() as $meta_key ) {
                 $object->delete_meta_data( $meta_key );
-                // delete_post_meta( $object->get_id(), $meta_key );
             }
             return true;
         }

--- a/lowest-price.php
+++ b/lowest-price.php
@@ -198,6 +198,7 @@ class Lowest_Price {
     public function update_price( $object_id, $new_price, $regular_price ) {
 
         if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
+            delete_post_meta( $object_id, '_lowest_price_30_days' );
             return;
         }
 
@@ -281,6 +282,7 @@ class Lowest_Price {
     public function object_before_update( $object ) {
 
         if ( did_action( 'woocommerce_product_duplicate_before_save' ) ) {
+            delete_post_meta( $object->get_id(), '_lowest_price_30_days' );
             return;
         }
 


### PR DESCRIPTION
Prilikom stvaranja duplikata proizvoda:

- rano return-anje koristeći `did_action( 'woocommerce_product_duplicate_before_save' )`, da bi se izbjeglo stvaranje DB zapisa u tablici _price_history, 
- brisanje meta podatka "_lowest_price_30_days" (i za Simple i Variable proizvode), 
- brisanje meta podataka o rasponima cijena ( _min_variation_price, _max_variation_price itd. - vidi funkciju `exclude_meta`) za Variable proizvode,
- za 'variation' product type (post type) nullificiranje amounta za price, regular i sale price ( `$object->set_price( null ) `)

Stvaranje DB zapisa o najnižim cijenama i timestampovima za dupliciran proizvod se stvara u prvom spremanju ili objavljivanju duplikata proizvoda.